### PR TITLE
Spec incompliance: the truth of the error object should not depend on…

### DIFF
--- a/pyjsonrpc/rpcerror.py
+++ b/pyjsonrpc/rpcerror.py
@@ -31,7 +31,7 @@ class JsonRpcError(RuntimeError):
         self.message = message or self.message
         self.data = data
         self.code = code or self.code
-        assert self.code, "Error without code is not allowed."
+        assert self.code is not None, "Error without code is not allowed."
 
     def __str__(self):
         return "JsonRpcError({code}): {message}".format(

--- a/pyjsonrpc/rpcresponse.py
+++ b/pyjsonrpc/rpcresponse.py
@@ -20,7 +20,7 @@ class Response(Bunch):
             """
             :param code: Error code
             :param message: Error message
-            :param data: Additional error informations
+            :param data: Additional error information
             """
 
             Bunch.__init__(self)
@@ -29,7 +29,7 @@ class Response(Bunch):
             self.data = data
 
         def __len__(self):
-            return 1 if self.code else 0
+            return 0 if (self.code is None) or (self.message is None) else 1
 
 
     def __init__(


### PR DESCRIPTION
… the code being non 0.

According to the JSON_RPC v2.0 specs (http://www.jsonrpc.org/specification),
the error response should contain an 'error' object which has at
least 'code' and 'message' objects, hence the truth of the error
object should depend on their existence. Although not an optimum
selection, 0 is not disallowed as error code.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>