### PR TITLE
Drop support for EOL Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "pypy"
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
-coverage<4
+coverage
 nose

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     url = HOMEPAGE,
     download_url = DOWNLOAD_URL,
     packages = find_packages(),
+    python_requires="==2.7.*",
     classifiers = [
         #"Development Status :: 1 - Planning",
         # "Development Status :: 2 - Pre-Alpha",
@@ -47,6 +48,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 2 :: Only",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: System :: Networking",
         "Topic :: Internet :: WWW/HTTP",


### PR DESCRIPTION
Fixes #47.

Python 2.6 is EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.6 | 2008-10-01 | 2013-10-29

Source: https://en.wikipedia.org/wiki/CPython#Version_history

It's also little used. Here's the pip installs for python-jsonrpc from PyPI for December 2018:

| category | percent | downloads |
|----------|--------:|----------:|
|      2.7 |  95.80% |     5,538 |
| null     |   2.27% |       131 |
|      3.6 |   1.11% |        64 |
|      3.7 |   0.62% |        36 |
|      3.5 |   0.14% |         8 |
|      2.6 |   0.05% |         3 |
|      3.4 |   0.02% |         1 |
| Total    |         |     5,781 |

Source: `pypistats python_minor --last-month python-jsonrpc`